### PR TITLE
Update de test.py para que la aleatoriedad no rompa los resultados

### DIFF
--- a/exercises/17-Russian-Roulette/test.py
+++ b/exercises/17-Russian-Roulette/test.py
@@ -1,30 +1,38 @@
 import io
 import sys
+import os
+import re
+import pytest
+from unittest.mock import patch
+
 sys.stdout = buffer = io.StringIO()
 
-# from app import my_function
-import pytest
-import app
-import re
-import os
-
 @pytest.mark.it('The function spin_chamber must exist')
-def test_function_spin_chamber(capsys, app):
+def test_function_spin_chamber(capsys):
+    import app
     assert app.spin_chamber
 
 @pytest.mark.it('The function fire_gun must exist')
-def test_function_fire_gun(capsys, app):
+def test_function_fire_gun(capsys):
+    import app
     assert app.fire_gun
 
 @pytest.mark.it('The function fire_gun should return the expected output in both cases')
-def test_function_output(capsys, app):
-    if(app.spin_chamber() == app.bullet_position):
-        assert app.fire_gun() == "You are dead!"
-    else:
-        assert app.fire_gun() == "Keep playing!"
+def test_function_output(capsys):
+    import app
+    chamber_position = app.spin_chamber()
+
+    # Simulamos la función spin_chamber para que devuelva la misma posición de la recámara
+    # durante la prueba para evitar que la aleatoriedad afecte los resultados
+    with patch('app.spin_chamber', return_value=chamber_position):
+        if chamber_position == app.bullet_position:
+            assert app.fire_gun() == "You are dead!"
+        else:
+            assert app.fire_gun() == "Keep playing!"
 
 @pytest.mark.it('Your code needs to print the correct output on the console')
 def test_for_file_output(capsys):
+    import app
     f = open(os.path.dirname(os.path.abspath(__file__))+'/app.py')
     content = f.readlines()
     content = [x.strip() for x in content]
@@ -32,6 +40,3 @@ def test_for_file_output(capsys):
     my_codeCallVar = content.index(my_codeCall[0])
     regex = r"print\(fire_gun\(\)\)"
     assert re.match(regex, content[my_codeCallVar])
-
-
-


### PR DESCRIPTION
**Ejercicio 17**

He eliminado el import global de 'app' y lo he añadido al principio de cada función test. Al importar el 'app' dentro de cada función de prueba, print(fire_gun()) se ejecuta solo cuando las pruebas están en curso, asegurando que las pruebas pasen de manera consistente ya que no se llama a la función varias veces, que estaba dando error a la hora de hacer los tests.

He utilizado la biblioteca unittest de python, la línea 27 with patch('app.spin_chamber', return_value=chamber_position): está utilizando la función patch para reemplazar temporalmente la función app.spin_chamber con una función simulada asegurando que los resultados de las pruebas no se vean afectados por la aleatoriedad introducida por la función spin_chamber.